### PR TITLE
BAU: Performance Tests for Application Store API Changes

### DIFF
--- a/data/application_store/new_application.json
+++ b/data/application_store/new_application.json
@@ -15,13 +15,13 @@
                     "key": "applicant-email",
                     "title": "Email",
                     "type": "text",
-                    "answer": "bob@bob.com"
+                    "answer": "a@example.com"
                 },
                 {
                     "key": "applicant-telephone-number",
                     "title": "Telephone number",
                     "type": "text",
-                    "answer": "01206 394204"
+                    "answer": "01632 960 000"
                 },
                 {
                     "key": "applicant-website",

--- a/data/application_store/new_application.json
+++ b/data/application_store/new_application.json
@@ -533,6 +533,8 @@
         }
     ],
     "metadata": {
-        "paymentSkipped": false
+        "paymentSkipped": false,
+        "application_id": "uuidv4"
     }
+    
 }

--- a/data/application_store/new_application.json
+++ b/data/application_store/new_application.json
@@ -1,7 +1,8 @@
 {
-    "name": "funding service design",
+    "name": "about-your-org",
     "questions": [
         {
+            
             "question": "About your organisation",
             "fields": [
                 {

--- a/my_locustfiles/application_store.py
+++ b/my_locustfiles/application_store.py
@@ -14,13 +14,14 @@ class ApplicationStore(HttpUser):
     )
     new_application_json = json.loads(new_application_json_file.read())
 
+
     @task
-    def post_new_application(self):
+    def put_new_application(self):
         """
-        Performance test for POST /application that expects a 201
+        Performance test for PUT /applications/sections that expects a 201
         """
-        with self.client.post(
-            "/applications",
+        with self.client.put(
+            "/applications/sections",
             json=self.new_application_json,
             catch_response=True,
         ) as response:
@@ -32,7 +33,7 @@ class ApplicationStore(HttpUser):
         Performance test for GET /applications?fund_id={fund_id} that expects a 200
         """
         with self.client.get(
-            "/applications/search?fund_id=''", catch_response=True
+            "/applications?fund_id=''", catch_response=True
         ) as response:
             check_expected_status(response, 200)
 

--- a/my_locustfiles/application_store.py
+++ b/my_locustfiles/application_store.py
@@ -13,17 +13,6 @@ class ApplicationStore(HttpUser):
         "./data/application_store/new_application.json", "r"
     )
     new_application_json = json.loads(new_application_json_file.read())
-    fund_id = "test-fund-name"
-
-    @task
-    def get_all_applications(self):
-        """
-        Performance test for GET /applications that expects a 200
-        """
-        with self.client.get(
-            "/applications", catch_response=True
-        ) as response:
-            check_expected_status(response, 200)
 
     @task
     def post_new_application(self):
@@ -43,6 +32,7 @@ class ApplicationStore(HttpUser):
         Performance test for GET /applications?fund_id={fund_id} that expects a 200
         """
         with self.client.get(
-            f"/applications?fund_id={self.fund_id}", catch_response=True
+            "/applications/search?fund_id=''", catch_response=True
         ) as response:
             check_expected_status(response, 200)
+


### PR DESCRIPTION
There has been some changes made to the Application Store API which has caused a couple of tests to be broken. 

I have removed the test for def get_all_applications(self): as that is no longer queryable in the Application Store API.

I have updated the test for POST /applications to PUT /applications/sections

I have made changes to the get_applications_for_a_fund test as it is no longer required to have a fund ID so have made the string empty. 

I have  changed the "name": from "funding service design" to "about-your-org" in the JSON payload.

Evidence of all the tests passing following the changes I have made:

![image](https://user-images.githubusercontent.com/36962596/169802389-348622f4-7c42-4125-b52c-840f51d26b6f.png)
