### PR TITLE
BAU: Fix Fund Store Tests

### DIFF
--- a/my_locustfiles/fund_store.py
+++ b/my_locustfiles/fund_store.py
@@ -6,8 +6,8 @@ from locust import task
 
 class FundStore(HttpUser):
     host = FUND_STORE
-    fund_id = "funding-service-design"
-    round_id = "spring"
+    fund_id = "47aef2f5-3fcb-4d45-acb5-f0152b5f03c4"
+    round_id = "c603d114-5364-4474-a0c4-c41cbf4d3bbd"
     search_query = "breakfast,fund"
 
     @task


### PR DESCRIPTION
As per recent changes to the Fund Store:
https://github.com/communitiesuk/funding-service-design-fund-store/pull/12

Fund and Round IDs are no longer generated and are now GUIDs. 

Evidence of tests passing
![image](https://user-images.githubusercontent.com/36962596/184164988-a8ad8515-e6bc-4a60-963c-487afec02bb7.png)
