### PR TITLE
BAU: Changed python-version

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -21,7 +21,7 @@ jobs:
         - name: Set up Python
           uses: actions/setup-python@v4
           with:
-            python-version: 3.10.1
+            python-version: 3.10.x
         - name: Install dependencies
           run: python -m pip install --upgrade pip && python -m pip install -r requirements.txt
         - name: Run Bandit


### PR DESCRIPTION
Version 3.10.1 is no longer available as per this recent run:
https://github.com/communitiesuk/funding-service-design-performance-tests/actions/runs/3656214554/jobs/6178395792


So I have changed the version in this PR.