### PR TITLE
FS-1200: Correct env var spelling for assessment store

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -33,7 +33,7 @@ jobs:
             path: bandit_security.json
             retention-days: 5
         - name: Run performance tests
-          run: python -m locust --users 3 --spawn-rate 1 --run-time 1s --headless
+          run: python -m locust --users 3 --spawn-rate 1 --run-time 15s --headless
           continue-on-error: true
         - name: Upload Pylama Report
           uses: actions/upload-artifact@v3

--- a/common/config.py
+++ b/common/config.py
@@ -14,7 +14,7 @@ APPLICATION_STORE = getenv(
 )
 
 ASSESSMENT_STORE = getenv (
-    "TARGET_URL_ASESSMENT_STORE",
+    "TARGET_URL_ASSESSMENT_STORE",
     "https://funding-service-design-assessment-store-dev.london.cloudapps.digital",
 )
 


### PR DESCRIPTION
### Change description

https://digital.dclg.gov.uk/jira/browse/FS-1200

PR to correct the env var spelling for Assessment Store as it was causing the performance test for assessment store to default to Dev when it was running in the pipelines after a deploy to Test.

![image](https://user-images.githubusercontent.com/36962596/221178416-e5e6e0a7-bd1c-4d31-aad5-7717ce0f27eb.png)






### How to test
N/A


### Screenshots of UI changes (if applicable)
N/A
