### PR TITLE
BAU: Remove PUT Performance Test & Add New POST Performance Test for Application Store

### DIFF
--- a/data/application_store/new_application.json
+++ b/data/application_store/new_application.json
@@ -1,8 +1,6 @@
 {
-    "metadata": {
-      "application_id": "c8be88f3-b138-4807-b948-95ace04a36d7",
-      "form_name": "declarations"
-    },
-    "name": "funding round title",
-    "questions": []
-  }
+  "account_id": "usera",
+  "fund_id": "47aef2f5-3fcb-4d45-acb5-f0152b5f03c4",
+  "language": "en",
+  "round_id": "c603d114-5364-4474-a0c4-c41cbf4d3bbd"
+}

--- a/my_locustfiles/application_store.py
+++ b/my_locustfiles/application_store.py
@@ -15,23 +15,19 @@ class ApplicationStore(HttpUser):
     )
     new_application_json = json.loads(new_application_json_file.read())
 
-
     @task
-    def put_new_application(self):
+    def post_new_application(self):
         """
-        Performance test for PUT /applications/forms that expects a 201 or 200
+        Performance test for POST /applications that expects a 201
         """
-        with self.client.put(
-            "/applications/forms",
+        with self.client.post(
+            "/applications",
             json=self.new_application_json,
             headers={"User-Agent": USER_AGENT},
-            catch_response=True,
+            catch_response=True, 
         ) as response:
-            if response.status_code == 201:
-               check_expected_status(response, 201)
-            else:
-               check_expected_status(response, 200)
-
+             check_expected_status(response, 201)
+           
     @task
     def get_applications_for_a_fund(self):
         """
@@ -42,5 +38,5 @@ class ApplicationStore(HttpUser):
             headers={"User-Agent": USER_AGENT},
             catch_response=True,
         ) as response:
-            check_expected_status(response, 200)
+             check_expected_status(response, 200)
 


### PR DESCRIPTION
### Change description

Related to:
https://github.com/communitiesuk/funding-service-design-performance-tests/pull/54


There was a 404 with the PUT performance test on Dev where the application ID no longer exists in that environment, but the test was passing on Test.
https://github.com/communitiesuk/funding-service-design-application-store/actions/runs/4542132443/jobs/8005304609


The PUT performance test requires an active application ID and for it to be working in both environments. I have now removed this due to the unreliability of the test between environments. 


I have added a new test as its replacement which registers a new application for a user. This test passes in both Dev and Test and does not require an application ID.


### How to test
Run the performance tests manually against Dev and Test locally by modifying the config.py file. 

### Screenshots of UI changes (if applicable)

N/A
